### PR TITLE
Fix laps added during replay being silently dropped

### DIFF
--- a/RaceLib/RaceManager.cs
+++ b/RaceLib/RaceManager.cs
@@ -1482,7 +1482,10 @@ namespace RaceLib
                 return;
 
             // If its added manually by race director every lap is valid. All training laps are valid.
-            if (detection.TimingSystemType != TimingSystemType.Manual || EventType != EventTypes.Training)
+            // (Validate only auto detections in non-training events. A previous '||' here invalidated
+            //  manual director-added laps in Race events - e.g. laps added during replay of a
+            //  finished race, where TimesUp is true - contradicting the comment above.)
+            if (detection.TimingSystemType != TimingSystemType.Manual && EventType != EventTypes.Training)
             {
                 // We start the timer before the race start, so just ignore any times in there...
                 // For handicapped pilots, gate against their personal staggered start instead of Race.Start.

--- a/UI/Nodes/LapsNode.cs
+++ b/UI/Nodes/LapsNode.cs
@@ -176,7 +176,11 @@ namespace UI.Nodes
 
             if (playbackTime.HasValue)
             {
-                laps = laps.Where(lap => lap.Detection.Time < playbackTime.Value).ToArray();
+                // Use <= so a lap whose detection time is exactly the current playback
+                // position (e.g. one just added via "Add Lap Now" while paused) is included.
+                // Must match the comparison in SetPlaybackTime, otherwise this path (reached
+                // via ChannelNodeBase's OnLapDetected handler) runs after it and hides the lap.
+                laps = laps.Where(lap => lap.Detection.Time <= playbackTime.Value).ToArray();
             }
 
             RefreshData(laps);
@@ -202,8 +206,12 @@ namespace UI.Nodes
                         Lap lap = laps[lapIndex];
                         if (lap == null)
                             continue;
-                        
+
                         lapNode.SetLap(lap);
+                        // Apply visibility here too, not only in Update(): while replay is
+                        // paused the per-frame Update tick doesn't reveal a freshly added lap,
+                        // so set it immediately to keep the data and the displayed rows in sync.
+                        lapNode.Visible = true;
 
                         int pbLaps = EventManager.Event.PBLaps;
 
@@ -226,6 +234,7 @@ namespace UI.Nodes
                     else
                     {
                         lapNodes[i].Clear();
+                        lapNodes[i].Visible = false;
                     }
                 }
             }
@@ -414,6 +423,13 @@ namespace UI.Nodes
 
                 if (!r.HasPilot(Pilot))
                     return;
+
+                // Grow/shrink the lap-cell table to fit the pilot's current lap count. Without
+                // this, a lap added during replay has no cell to display in (the array-based
+                // RefreshData never resizes the table), so it only shows once an UpdateLapCount
+                // happens on unpause.
+                if (lapsPerRow != GetLapsPerRowCount() || LapLines != table.Rows)
+                    UpdateLapCount();
 
                 Lap[] laps = r.GetValidLaps(Pilot, true).OrderBy(l => l.End).Where(lap => lap.Detection.Time <= playbackTime.Value).ToArray();
 

--- a/UI/Video/ReplayNode.cs
+++ b/UI/Video/ReplayNode.cs
@@ -131,7 +131,12 @@ namespace UI.Video
             if (primary != null && race != null)
             {
                 SeekNode.SetRace(race, minStart, maxEnd);
-                ChannelsGridNode.SetPlaybackTime(CurrentTime);
+                // Use the frame source's full-precision time rather than SeekNode.CurrentTime,
+                // which round-trips through a float progress factor. A lap added at the current
+                // playback position has Detection.Time == primary.CurrentTime; the lossy seek time
+                // could round just below it and cause SetPlaybackTime's "Detection.Time <= time"
+                // filter to drop the freshly added lap from the replay list.
+                ChannelsGridNode.SetPlaybackTime(primary.CurrentTime);
             }
         }
 


### PR DESCRIPTION
Adding a lap during replay via "Add Lap Now" had stopped working: the lap was recorded as invalid and never counted, and even when valid it did not appear in the lap list until the replay was unpaused.

Root cause (regression): RaceManager.AddLap had its validity guard widened (commit d63583d7) from "!= Manual" to "!= Manual || EventType != Training". That ran manual, race-director-added laps in Race events through the live-timing validity checks. During replay of a finished race TimesUp is true, so the lap was flagged invalid and dropped. Restored to "&&" so manual laps are always valid (matching the method's own comment) while still keeping all training laps valid.

Also fixes long-standing replay lap-list refresh issues so an added lap shows immediately while paused instead of only after unpausing:
- ReplayNode.OnChange refreshes with the frame source's full-precision time rather than SeekNode.CurrentTime, which round-trips through a float and could land just below a lap sitting exactly on the playback boundary.
- LapsNode.RefreshData applies row visibility immediately (it was only set on the per-frame Update tick), and SetPlaybackTime resizes the lap-cell table so the new lap has a cell to render in.
- The no-arg RefreshData time filter uses "<=" to match SetPlaybackTime, so the boundary lap is not hidden by the OnLapDetected refresh path.